### PR TITLE
 adjustment init.sh to ease in re-creation of cfn stack

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -91,7 +91,7 @@ then
     echo "Region: $REGION"
     echo "S3Bucket: $S3_BUCKET"
     echo ""
-    echo "For the ProductId param use the Product ID of the ADX product you just created"
+    echo "For the ProductId param use the Product ID of the ADX product"
     echo ""
   else
     # Cloudformation stack deletion failed


### PR DESCRIPTION
returns the params needed to re-create the cfn stack at the end of a successful cfn stack deletion